### PR TITLE
Make the canvas endless

### DIFF
--- a/lib/editor.dart
+++ b/lib/editor.dart
@@ -21,14 +21,7 @@ class Editor extends StatelessWidget {
     return MultiProvider(
       providers: [
         ChangeNotifierProvider<Document>(create: (_) {
-          final doc = Document();
-          final initialCanvasSize = EditorDimensions.visibleCanvasArea(context).size -
-              Offset(
-                EditorDimensions.canvasMargin * 2,
-                EditorDimensions.canvasMargin * 2,
-              );
-          doc.resizeCanvas(initialCanvasSize);
-          return doc;
+          return Document();
         }),
         ChangeNotifierProvider<Selection>(create: (_) => Selection()),
         ChangeNotifierProvider<EditorState>(create: (_) => EditorState()),
@@ -73,36 +66,20 @@ class Editor extends StatelessWidget {
 class DesignEditor extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    final document = Provider.of<Document>(context);
+    final editorState = Provider.of<EditorState>(context);
 
     return Stack(
       children: [
-        Container(
-          color: Theme.of(context).dialogBackgroundColor,
-        ),
-        Positioned(
-          left: EditorDimensions.canvasMargin,
-          top: EditorDimensions.canvasMargin,
-          width: document.canvasSize.width,
-          height: document.canvasSize.height,
-          child: Consumer<EditorState>(
-            builder: (context, editorState, child) {
-              return Transform(
-                transform: Matrix4.translationValues(
-                  editorState.canvasOffset.dx,
-                  editorState.canvasOffset.dy,
-                  0,
-                )..scale(editorState.zoomScale, editorState.zoomScale, 1),
-                child: Stack(
-                  children: [
-                    CanvasLayer(),
-                    EdgesLayer(),
-                    NodesLayer(),
-                    PointerLayer(),
-                  ],
-                ),
-              );
-            },
+        CanvasLayer(), // endless scrolling
+        Transform.scale(
+          scale: editorState.zoomScale,
+          alignment: Alignment.topLeft,
+          child: Stack(
+            children: [
+              EdgesLayer(),
+              NodesLayer(),
+              PointerLayer(),
+            ],
           ),
         ),
       ],

--- a/lib/editor.dart
+++ b/lib/editor.dart
@@ -8,6 +8,7 @@ import 'models/editor_state.dart';
 import 'toolbar.dart';
 import 'object_library.dart';
 import 'property_inspector.dart';
+import 'ruler.dart';
 
 import 'views/editor/editor_dimensions.dart';
 import 'views/editor/canvas_layer.dart';
@@ -29,11 +30,25 @@ class Editor extends StatelessWidget {
       child: Stack(
         children: [
           Positioned(
-            top: EditorDimensions.toolbarHeight,
-            left: EditorDimensions.objectLibraryPanelWidth,
+            top: EditorDimensions.toolbarHeight + EditorDimensions.rulerWidth,
+            left: EditorDimensions.objectLibraryPanelWidth + EditorDimensions.rulerWidth,
             right: EditorDimensions.propertyInspectorPanelWidth,
             bottom: 0,
             child: DesignEditor(),
+          ),
+          Positioned(
+            top: EditorDimensions.toolbarHeight + EditorDimensions.rulerWidth - 1,
+            left: EditorDimensions.objectLibraryPanelWidth,
+            bottom: 0,
+            width: EditorDimensions.rulerWidth,
+            child: Ruler(RulerDirection.vertical),
+          ),
+          Positioned(
+            top: EditorDimensions.toolbarHeight,
+            left: EditorDimensions.objectLibraryPanelWidth + EditorDimensions.rulerWidth - 1,
+            right: EditorDimensions.propertyInspectorPanelWidth,
+            height: EditorDimensions.rulerWidth,
+            child: Ruler(RulerDirection.horizontal),
           ),
           Positioned(
             top: EditorDimensions.toolbarHeight,

--- a/lib/editor.dart
+++ b/lib/editor.dart
@@ -93,10 +93,14 @@ class DesignEditor extends StatelessWidget {
             children: [
               EdgesLayer(),
               NodesLayer(),
-              PointerLayer(),
             ],
           ),
         ),
+
+        /// Pointer layer doesn't scale with edges/nodes to make sure even when
+        /// drawing area is smaller than canvas background events outside that
+        /// area are still handled.
+        PointerLayer(),
       ],
     );
   }

--- a/lib/models/document.dart
+++ b/lib/models/document.dart
@@ -13,6 +13,8 @@ class Document extends ChangeNotifier {
   UnmodifiableListView<Node> get nodes => UnmodifiableListView(_allNodes);
   UnmodifiableListView<Link> get links => UnmodifiableListView(_links);
 
+  RootNode get root => _allNodes.firstWhere((n) => n is RootNode);
+
   Document() {
     final root = RootNode();
     final callResult = NodeCreator.create(

--- a/lib/models/document.dart
+++ b/lib/models/document.dart
@@ -1,22 +1,17 @@
 import 'dart:collection';
-import 'dart:math';
-import 'dart:ui' show Offset, Size;
+import 'dart:ui' show Offset;
 import 'package:flutter/foundation.dart';
 
 import 'node.dart';
 import 'link.dart';
 
 class Document extends ChangeNotifier {
-  static const Size _minimalCanvasSize = Size(1440, 900);
-
   final List<Node> _topLevelNodes = []; // Reference to top level nodes only
   final List<Node> _allNodes = [];
   final List<Link> _links = [];
-  Size _canvasSize = _minimalCanvasSize;
 
   UnmodifiableListView<Node> get nodes => UnmodifiableListView(_allNodes);
   UnmodifiableListView<Link> get links => UnmodifiableListView(_links);
-  Size get canvasSize => _canvasSize;
 
   Document() {
     final root = RootNode();
@@ -28,18 +23,6 @@ class Document extends ChangeNotifier {
     root.addChild(callResult, root.addCallSlot('call result').id);
 
     addNode(root);
-  }
-
-  void resizeCanvas(Size size) {
-    if (size == _canvasSize) {
-      return;
-    }
-
-    _canvasSize = Size(
-      max(size.width, _minimalCanvasSize.width),
-      max(size.height, _minimalCanvasSize.height),
-    );
-    notifyListeners();
   }
 
   void addNode(Node node, {Node parent}) {

--- a/lib/models/editor_state.dart
+++ b/lib/models/editor_state.dart
@@ -26,6 +26,11 @@ class EditorState extends ChangeNotifier {
     return zoomOut;
   }
 
+  void resetCanvasOffset() {
+    _canvasOffset = Offset.zero;
+    notifyListeners();
+  }
+
   void moveCanvas(Offset offset) {
     _canvasOffset += offset;
     notifyListeners();

--- a/lib/models/nodes/node_base.dart
+++ b/lib/models/nodes/node_base.dart
@@ -226,14 +226,17 @@ class Node extends NodeBase with ChangeNotifier {
         return slots[i];
       }
     }
-    final addCallButtonRect = Rect.fromLTWH(
-      size.width - hitWidth,
-      verticalOffset + slotRowHeight * slots.length,
-      hitWidth,
-      slotRowHeight,
-    );
-    if (addCallButtonRect.contains(point)) {
-      return addChildSlot;
+
+    if (canAddSlot) {
+      final addSlotButtonRect = Rect.fromLTWH(
+        size.width - hitWidth,
+        verticalOffset + slotRowHeight * slots.length,
+        hitWidth,
+        slotRowHeight,
+      );
+      if (addSlotButtonRect.contains(point)) {
+        return addChildSlot;
+      }
     }
 
     return null;

--- a/lib/ruler.dart
+++ b/lib/ruler.dart
@@ -1,0 +1,176 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'models/editor_state.dart';
+
+enum RulerDirection {
+  horizontal,
+  vertical,
+}
+
+class Ruler extends StatelessWidget {
+  Ruler(this.direction);
+  final RulerDirection direction;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: Theme.of(context).colorScheme.surface,
+      child: direction == RulerDirection.horizontal
+          ? _drawHorizontal(context)
+          : _drawVertical(context),
+    );
+  }
+
+  /// TODO: zoom, offset, number
+
+  Widget _drawHorizontal(BuildContext context) {
+    final editorState = Provider.of<EditorState>(context);
+    return Container(
+      decoration: BoxDecoration(
+        border: Border(
+          left: BorderSide(
+            width: 1,
+            color: Theme.of(context).dividerColor,
+          ),
+          bottom: BorderSide(
+            width: 1,
+            color: Theme.of(context).dividerColor,
+          ),
+        ),
+      ),
+      child: CustomPaint(
+        painter: _RulerPainter(
+          direction,
+          editorState.canvasOffset,
+          editorState.zoomScale,
+          Theme.of(context).textTheme.bodyText1.color,
+        ),
+        child: Container(),
+      ),
+    );
+  }
+
+  Widget _drawVertical(BuildContext context) {
+    final editorState = Provider.of<EditorState>(context);
+    return Container(
+      decoration: BoxDecoration(
+        border: Border(
+          top: BorderSide(
+            width: 1,
+            color: Theme.of(context).dividerColor,
+          ),
+          right: BorderSide(
+            width: 1,
+            color: Theme.of(context).dividerColor,
+          ),
+        ),
+      ),
+      child: CustomPaint(
+        painter: _RulerPainter(
+          direction,
+          editorState.canvasOffset,
+          editorState.zoomScale,
+          Theme.of(context).textTheme.bodyText1.color,
+        ),
+        child: Container(),
+      ),
+    );
+  }
+}
+
+class _RulerPainter extends CustomPainter {
+  _RulerPainter(this._direction, this._canvasOffset, this._scale, this._textColor);
+
+  final RulerDirection _direction;
+  final Offset _canvasOffset;
+  final double _scale;
+  final Color _textColor;
+  double get _largeMarker {
+    if (_scale < 0.6) {
+      return 400.0;
+    }
+    if (_scale < 1.0) {
+      return 200.0;
+    }
+    return 100.0;
+  }
+
+  double get _smallMarker {
+    if (_scale <= 0.6) {
+      return _largeMarker / 5;
+    }
+    return _largeMarker / 10;
+  }
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    canvas.clipRect(Rect.fromLTWH(0, 0, size.width, size.height));
+    var paint = Paint()
+      ..isAntiAlias = true
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 1
+      ..color = Colors.grey[300];
+
+    final path = Path();
+    final step = _smallMarker * _scale;
+    if (_direction == RulerDirection.horizontal) {
+      final start = _canvasOffset.dx % _smallMarker * _scale;
+      for (var i = 0.0; i < size.width / step; i++) {
+        final x = start + i * step;
+        final position = (x / _scale - _canvasOffset.dx).round();
+        final isLargeMarker = position % _largeMarker.toInt() == 0;
+        final height = isLargeMarker ? size.height : size.height / 3;
+        path.moveTo(x, size.height - height);
+        path.lineTo(x, size.height);
+
+        if (isLargeMarker) {
+          final span = TextSpan(
+            style: TextStyle(color: _textColor, fontSize: 10),
+            text: '$position',
+          );
+          final textPainter = TextPainter(
+            text: span,
+            textAlign: TextAlign.left,
+            textDirection: TextDirection.ltr,
+          );
+          textPainter.layout();
+          textPainter.paint(canvas, Offset(x + 4, 0));
+        }
+      }
+    } else {
+      final start = _canvasOffset.dy % _smallMarker * _scale;
+      for (var i = 0.0; i < size.height / step; i++) {
+        final y = start + i * step;
+        final position = (y / _scale - _canvasOffset.dy).round();
+        final isLargeMarker = position % _largeMarker.toInt() == 0;
+        final width = isLargeMarker ? size.width : size.width / 3;
+        path.moveTo(size.width - width, y);
+        path.lineTo(size.width, y);
+
+        if (isLargeMarker) {
+          final span = TextSpan(
+            style: TextStyle(color: _textColor, fontSize: 10),
+            text: '$position',
+          );
+          final textPainter = TextPainter(
+            text: span,
+            textAlign: TextAlign.left,
+            textDirection: TextDirection.ltr,
+          );
+          textPainter.layout();
+          canvas.translate(0, y);
+          canvas.rotate(-1.5708);
+          textPainter.paint(canvas, Offset(4, 0));
+          canvas.rotate(1.5708);
+          canvas.translate(0, -y);
+        }
+      }
+    }
+
+    canvas.drawPath(path, paint);
+  }
+
+  @override
+  bool shouldRepaint(_RulerPainter old) => false;
+}

--- a/lib/toolbar.dart
+++ b/lib/toolbar.dart
@@ -21,27 +21,27 @@ class Toolbar extends StatelessWidget {
           crossAxisAlignment: WrapCrossAlignment.center,
           children: [
             SizedBox(width: 20),
-            IconButton(
+            _iconButton(
               icon: Icon(Icons.note_add),
               onPressed: null,
             ),
-            IconButton(
+            _iconButton(
               icon: Icon(Icons.file_download),
               onPressed: null,
             ),
-            IconButton(
+            _iconButton(
               icon: Icon(Icons.file_upload),
               onPressed: null,
             ),
             _separator(),
-            IconButton(
+            _iconButton(
               icon: Icon(Icons.zoom_out),
               onPressed: editorState.zoomOutAction,
             ),
             SizedBox(
               width: 30,
               child: Text(
-                '${(editorState.zoomScale * 100).round().toInt()}%',
+                '${(editorState.zoomScale * 100).round()}%',
                 textAlign: TextAlign.center,
                 style: TextStyle(
                   color: Colors.grey,
@@ -49,7 +49,7 @@ class Toolbar extends StatelessWidget {
                 ),
               ),
             ),
-            IconButton(
+            _iconButton(
               icon: Icon(Icons.zoom_in),
               onPressed: editorState.zoomInAction,
             ),
@@ -57,6 +57,16 @@ class Toolbar extends StatelessWidget {
         ),
       );
     });
+  }
+
+  Widget _iconButton({Widget icon, Function onPressed}) {
+    return IconButton(
+      icon: icon,
+      onPressed: onPressed,
+      hoverColor: Colors.transparent,
+      highlightColor: Colors.transparent,
+      splashColor: Colors.transparent,
+    );
   }
 
   Widget _separator() {

--- a/lib/toolbar.dart
+++ b/lib/toolbar.dart
@@ -1,12 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import 'models/document.dart';
 import 'models/editor_state.dart';
+import 'models/node.dart';
 
 class Toolbar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return Consumer<EditorState>(builder: (context, editorState, child) {
+    return Consumer2<Document, EditorState>(builder: (context, document, editorState, child) {
       return Container(
         decoration: BoxDecoration(
           color: Theme.of(context).canvasColor,
@@ -52,6 +54,22 @@ class Toolbar extends StatelessWidget {
             _iconButton(
               icon: Icon(Icons.zoom_in),
               onPressed: editorState.zoomInAction,
+            ),
+            _separator(),
+            _iconButton(
+              icon: Icon(Icons.filter_center_focus),
+              onPressed: () {
+                editorState.resetCanvasOffset();
+              },
+            ),
+            _iconButton(
+              icon: Icon(Icons.developer_board),
+              onPressed: () {
+                final root = document.root;
+                editorState.resetCanvasOffset();
+                final pos = root.position + Offset(-80, -200);
+                editorState.moveCanvas(-pos);
+              },
             ),
           ],
         ),

--- a/lib/toolbar.dart
+++ b/lib/toolbar.dart
@@ -3,7 +3,6 @@ import 'package:provider/provider.dart';
 
 import 'models/document.dart';
 import 'models/editor_state.dart';
-import 'models/node.dart';
 
 class Toolbar extends StatelessWidget {
   @override

--- a/lib/views/editor/canvas_layer.dart
+++ b/lib/views/editor/canvas_layer.dart
@@ -1,14 +1,20 @@
 import 'dart:ui' show PointMode;
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../models/editor_state.dart';
 
 class CanvasLayer extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
+    final gridColor = Theme.of(context).textTheme.caption.color;
+    final editorState = Provider.of<EditorState>(context);
+
     return Material(
       color: Theme.of(context).colorScheme.surface,
       elevation: 2,
       child: CustomPaint(
-        painter: _CanvasGridPainter(Theme.of(context).textTheme.caption.color),
+        painter: _CanvasGridPainter(gridColor, editorState.canvasOffset),
         child: Container(),
       ),
     );
@@ -16,18 +22,21 @@ class CanvasLayer extends StatelessWidget {
 }
 
 class _CanvasGridPainter extends CustomPainter {
-  _CanvasGridPainter(this.gridColor);
-  final Color gridColor;
+  _CanvasGridPainter(this._gridColor, this._canvasOffset);
+
+  final Color _gridColor;
+  final Offset _canvasOffset;
+  final double _gridSize = 20;
 
   @override
   void paint(Canvas canvas, Size size) {
     var paint = Paint()
       ..isAntiAlias = true
       ..strokeWidth = 1
-      ..color = gridColor;
+      ..color = _gridColor;
 
     /* /// Grid mode
-    for (var i = 20; i < size.width; i += 20) {
+    for (var i = _gridSize; i < size.width; i += _gridSize) {
       canvas.drawLine(
         Offset(i.toDouble(), 0),
         Offset(i.toDouble(), size.height),
@@ -35,7 +44,7 @@ class _CanvasGridPainter extends CustomPainter {
       );
     }
 
-    for (var i = 20; i < size.height; i += 20) {
+    for (var i = _gridSize; i < size.height; i += _gridSize) {
       canvas.drawLine(
         Offset(0, i.toDouble()),
         Offset(size.width, i.toDouble()),
@@ -43,9 +52,11 @@ class _CanvasGridPainter extends CustomPainter {
       );
     }*/
     /// Points mode
+
     final points = <Offset>[];
-    for (var i = 20; i < size.width; i += 20) {
-      for (var j = 20; j < size.height; j += 20) {
+    var start = _canvasOffset % _gridSize;
+    for (var i = start.dx; i < size.width; i += _gridSize) {
+      for (var j = start.dy; j < size.height; j += _gridSize) {
         points.add(Offset(i.toDouble(), j.toDouble()));
       }
     }

--- a/lib/views/editor/edges_layer.dart
+++ b/lib/views/editor/edges_layer.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../../models/document.dart';
+import '../../models/editor_state.dart';
 import '../../models/link.dart';
 import '../../utils/edge_path.dart';
 
@@ -11,9 +12,9 @@ import '../../utils/edge_path.dart';
 class EdgesLayer extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return Consumer<Document>(builder: (context, document, child) {
+    return Consumer2<Document, EditorState>(builder: (context, document, editorState, child) {
       return CustomPaint(
-        painter: _EdgesPainter(document.links),
+        painter: _EdgesPainter(document.links, editorState.canvasOffset),
         child: Container(),
       );
     });
@@ -21,8 +22,10 @@ class EdgesLayer extends StatelessWidget {
 }
 
 class _EdgesPainter extends CustomPainter {
+  _EdgesPainter(this.links, this.offset);
+
   List<Link> links;
-  _EdgesPainter(this.links);
+  Offset offset;
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -36,8 +39,8 @@ class _EdgesPainter extends CustomPainter {
 
     // Draw a test edge between every two nodes.
     for (final link in links) {
-      final start = link.parent.childConnectorPosition(link.child);
-      final end = link.child.position + Offset(0, 15);
+      final start = link.parent.childConnectorPosition(link.child) + offset;
+      final end = link.child.position + Offset(0, 15) + offset;
       final edge = EdgePath(start, end);
       canvas.drawPath(edge.edgePath, paint);
       canvas.drawPath(edge.arrowPath, paint);

--- a/lib/views/editor/edges_layer.dart
+++ b/lib/views/editor/edges_layer.dart
@@ -29,7 +29,7 @@ class _EdgesPainter extends CustomPainter {
 
   @override
   void paint(Canvas canvas, Size size) {
-    canvas.clipRect(Rect.fromLTWH(0, 0, size.width, size.height));
+    //canvas.clipRect(Rect.fromLTWH(0, 0, size.width, size.height));
 
     var paint = Paint()
       ..isAntiAlias = true

--- a/lib/views/editor/editor_dimensions.dart
+++ b/lib/views/editor/editor_dimensions.dart
@@ -2,16 +2,17 @@ import 'package:flutter/material.dart';
 
 class EditorDimensions {
   static const double toolbarHeight = 40;
+  static const double rulerWidth = 20;
   static const double objectLibraryPanelWidth = 180;
   static const double propertyInspectorPanelWidth = 280;
 
   static Rect visibleCanvasArea(BuildContext context) {
     final size = MediaQuery.of(context).size;
     return Rect.fromLTWH(
-      objectLibraryPanelWidth,
-      toolbarHeight,
-      size.width - objectLibraryPanelWidth - propertyInspectorPanelWidth,
-      size.height - toolbarHeight,
+      objectLibraryPanelWidth + rulerWidth,
+      toolbarHeight + rulerWidth,
+      size.width - objectLibraryPanelWidth - propertyInspectorPanelWidth - rulerWidth,
+      size.height - toolbarHeight - rulerWidth,
     );
   }
 }

--- a/lib/views/editor/editor_dimensions.dart
+++ b/lib/views/editor/editor_dimensions.dart
@@ -4,7 +4,6 @@ class EditorDimensions {
   static const double toolbarHeight = 40;
   static const double objectLibraryPanelWidth = 180;
   static const double propertyInspectorPanelWidth = 280;
-  static const double canvasMargin = 20;
 
   static Rect visibleCanvasArea(BuildContext context) {
     final size = MediaQuery.of(context).size;

--- a/lib/views/editor/nodes_layer.dart
+++ b/lib/views/editor/nodes_layer.dart
@@ -13,6 +13,7 @@ class NodesLayer extends StatelessWidget {
     return Consumer2<Document, Selection>(
       builder: (context, document, selection, child) {
         return Stack(
+          overflow: Overflow.visible,
           children: document.nodes.map((node) {
             return ChangeNotifierProvider<Node>.value(
               value: node,

--- a/lib/views/editor/nodes_layer.dart
+++ b/lib/views/editor/nodes_layer.dart
@@ -10,15 +10,17 @@ import '../node.dart';
 class NodesLayer extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return Consumer2<Document, Selection>(builder: (context, document, selection, child) {
-      return Stack(
-        children: document.nodes.map((node) {
-          return ChangeNotifierProvider<Node>.value(
-            value: node,
-            child: ViewCreator.create(node),
-          );
-        }).toList(),
-      );
-    });
+    return Consumer2<Document, Selection>(
+      builder: (context, document, selection, child) {
+        return Stack(
+          children: document.nodes.map((node) {
+            return ChangeNotifierProvider<Node>.value(
+              value: node,
+              child: ViewCreator.create(node),
+            );
+          }).toList(),
+        );
+      },
+    );
   }
 }

--- a/lib/views/editor/pointer_layer.dart
+++ b/lib/views/editor/pointer_layer.dart
@@ -61,20 +61,15 @@ class _PointerLayerState extends State<PointerLayer> {
               _endConnectorOffset,
             ),
           if (_isShowingContextMenu)
-            Positioned(
-              left: _contentMenuOffset.dx,
-              top: _contentMenuOffset.dy,
-              // Content menu should not be scaled
-              child: Transform(
-                transform: Matrix4.translationValues(0, 0, 0)
-                  ..scale(1 / editorState.zoomScale, 1 / editorState.zoomScale, 1),
-                child: ContextMenu(
-                  NodeActionBuilder(
-                    document,
-                    selection.selectedNode(document.nodes),
-                  ).build(),
-                  _handleActionItem,
-                ),
+            Transform(
+              transform: Matrix4.translationValues(_contentMenuOffset.dx, _contentMenuOffset.dy, 0)
+                ..scale(1 / editorState.zoomScale, 1 / editorState.zoomScale, 1),
+              child: ContextMenu(
+                NodeActionBuilder(
+                  document,
+                  selection.selectedNode(document.nodes),
+                ).build(),
+                _handleActionItem,
               ),
             ),
         ],
@@ -178,10 +173,8 @@ class _PointerLayerState extends State<PointerLayer> {
         _contentMenuOffset = menuOffset;
       });
     } else {
-      /// Do not rebuild immediately. This allows the button/action inside the context menu
-      /// to have enough time to respond if user clicks an menu item.
       if (_isShowingContextMenu) {
-        if (!menuSize().contains(localPosition - _contentMenuOffset)) {
+        if (!menuSize().contains(event.localPosition - _contentMenuOffset)) {
           // Not clicking menu items.
           setState(() {
             _isShowingContextMenu = false;

--- a/lib/views/editor/pointer_layer.dart
+++ b/lib/views/editor/pointer_layer.dart
@@ -33,7 +33,8 @@ class _PointerLayerState extends State<PointerLayer> {
   Selection get selection => Provider.of<Selection>(context, listen: false);
   EditorState get editorState => Provider.of<EditorState>(context, listen: false);
 
-  Offset _translateLocalPosition(Offset pos) => pos - editorState.canvasOffset;
+  Offset _translateLocalPosition(Offset pos) =>
+      pos / editorState.zoomScale - editorState.canvasOffset;
 
   @override
   Widget build(BuildContext context) {
@@ -56,14 +57,16 @@ class _PointerLayerState extends State<PointerLayer> {
             builder: (context, candidateData, rejectedData) => Container(),
           ),
           if (_isDraggingConnector)
-            _ConnectingNodesView(
-              _startConnectorOffset,
-              _endConnectorOffset,
+            Transform(
+              transform: Matrix4.translationValues(0, 0, 0)..scale(editorState.zoomScale),
+              child: _ConnectingNodesView(
+                _startConnectorOffset,
+                _endConnectorOffset,
+              ),
             ),
           if (_isShowingContextMenu)
             Transform(
-              transform: Matrix4.translationValues(_contentMenuOffset.dx, _contentMenuOffset.dy, 0)
-                ..scale(1 / editorState.zoomScale, 1 / editorState.zoomScale, 1),
+              transform: Matrix4.translationValues(_contentMenuOffset.dx, _contentMenuOffset.dy, 0),
               child: ContextMenu(
                 NodeActionBuilder(
                   document,

--- a/lib/views/nodes/node_view.dart
+++ b/lib/views/nodes/node_view.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 
 import '../../models/node.dart';
 import '../../models/selection.dart';
+import '../../models/editor_state.dart';
 
 class NodeView extends StatelessWidget {
   static const double borderRadius = 5;
@@ -125,6 +126,7 @@ class NodeView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final editorState = Provider.of<EditorState>(context);
     final node = Provider.of<Node>(context);
     final selection = Provider.of<Selection>(context, listen: false);
     final isSelected = selection.isNodeSelected(node);
@@ -134,8 +136,8 @@ class NodeView extends StatelessWidget {
         isSelected ? selectedBorderColor : (isHovered ? hoveredBorderColor : normalBorderColor);
 
     return Positioned(
-      left: node.position.dx,
-      top: node.position.dy,
+      left: node.position.dx + editorState.canvasOffset.dx,
+      top: node.position.dy + editorState.canvasOffset.dy,
       width: node.size.width,
       height: node.size.height,
       child: Stack(

--- a/test/models/editor_state_test.dart
+++ b/test/models/editor_state_test.dart
@@ -9,6 +9,14 @@ void main() {
     expect(state.canvasOffset, offsetMoreOrLessEquals(Offset(100, 100)));
   });
 
+  test('reset canvas offset', () {
+    final state = EditorState();
+    state.moveCanvas(Offset(100, 100));
+    expect(state.canvasOffset, offsetMoreOrLessEquals(Offset(100, 100)));
+    state.resetCanvasOffset();
+    expect(state.canvasOffset, offsetMoreOrLessEquals(Offset.zero));
+  });
+
   group('zooming', () {
     test('zoom in', () {
       final state = EditorState();

--- a/test/models/nodes/node_base_test.dart
+++ b/test/models/nodes/node_base_test.dart
@@ -8,6 +8,13 @@ class _SomeNode extends Node {
   int get maximumSlotCount => 3;
 }
 
+class _SingleNode extends Node {
+  @override
+  int get minimumSlotCount => 0;
+  @override
+  int get maximumSlotCount => 0;
+}
+
 void main() {
   group('child slot', () {
     test('is connected', () {
@@ -164,6 +171,12 @@ void main() {
       final node = Node();
       final pos = node.slotConnectorPosition(Node.addChildSlot) - node.position;
       expect(node.hitTest(pos), Node.addChildSlot);
+    });
+
+    test('no add child button', () {
+      final node = _SingleNode();
+      final pos = node.slotConnectorPosition(Node.addChildSlot) - node.position;
+      expect(node.hitTest(pos), null);
     });
   });
 }


### PR DESCRIPTION
To fix: content menu item tap event is broken when canvas offset is not zero.

Implementation note: this does make the offset and scale translation more complicated - now instead of doing that on the outer `DesignEditor` widget, layers of nodes, edges and pointers all need to handle it.

TODO

- [x] Fix content menu item tap event. It's currently broken if the canvas has offset.
- [x] When canvas is zoomed out (scale < 1), the full editor area should still accept pointer events.
- [x] Primitive node should not allow to drag connecting slot. (it doesn't have visible slot)