### PR TITLE
Repaint canvas layer when offset changes

### DIFF
--- a/lib/views/editor/canvas_layer.dart
+++ b/lib/views/editor/canvas_layer.dart
@@ -65,5 +65,5 @@ class _CanvasGridPainter extends CustomPainter {
   }
 
   @override
-  bool shouldRepaint(_CanvasGridPainter oldPainter) => false;
+  bool shouldRepaint(_CanvasGridPainter oldPainter) => _canvasOffset != oldPainter._canvasOffset;
 }


### PR DESCRIPTION
This fixes the canvas and ruler not updating issue when there's no visible node/edge.

Fixes #16.